### PR TITLE
Add sscan

### DIFF
--- a/src/M6Web/Component/RedisMock/RedisMock.php
+++ b/src/M6Web/Component/RedisMock/RedisMock.php
@@ -379,6 +379,16 @@ class RedisMock
 
         return $this->returnPipedInfo(self::$dataValues[$this->storage][$key]);
     }
+    
+    public function sscan($key, $cursor = '0', array $options = [])
+    {
+        if (!isset(self::$dataValues[$this->storage][$key]) || $this->deleteOnTtlExpired($key)) {
+            return $this->returnPipedInfo([,[]]);
+        }
+        // For the purposes of this mock we returning a simple chunk of all data similer to smembers
+        $chunk =  $this->returnPipedInfo(self::$dataValues[$this->storage][$key]);
+        return [$cursor, $chunk];
+    }
 
     public function sunion($key)
     {

--- a/src/M6Web/Component/RedisMock/RedisMockFactory.php
+++ b/src/M6Web/Component/RedisMock/RedisMockFactory.php
@@ -125,6 +125,7 @@ class RedisMockFactory
         'spop',
         'srandmember',
         'srem',
+        'sscan',
         'strlen',
         'subscribe',
         'sunion',


### PR DESCRIPTION
This is imperfect as we are not implementing the actual scan options, however for the purposes of mocking it should be sufficient for most uses cases.

This allows the use of tagged collections in Laravel ^8.76